### PR TITLE
feat: Adição do /block + tab para listar jogadores da partida

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -460,8 +460,34 @@ async fn handle_log_line(
         }
     }
 
+    // Checa se a mensagem é um comando de listagem de jogadores na sala (/block + tab) mostra somente os atuais da sala
+    // Formato: [CHAT] remove, remover, list, lista, nick1, nick2, nick3...
+    if line.contains("remove, remover, list, lista") && 
+       !app_mutex.lock().await.state.loading {
+        println!("Jogador usou /block + tab");
+        
+
+        if let Some(chat_content) = line.split("[CHAT]").nth(1) {
+            // Separa por vírgula e remove espaços
+            let str_players: Vec<String> = chat_content
+                .trim()
+                .split(',')
+                .map(|x| x.trim().to_string())
+                .filter(|x| !x.is_empty() && x != "remove" && x != "remover" && x != "list" && x != "lista")
+                .collect();
+
+            app_mutex.lock().await.state.loading = true;
+            handle.emit("loading", true).unwrap();
+
+            let cached_players = app_mutex.lock().await.state.cached_players.clone();
+            let stats_type = app_mutex.lock().await.settings.stats_type.clone();
+            player::get_players(str_players, stats_type, cached_players, handle, app_mutex).await;
+
+        }
+    }
+
     // Checa se a mensagem possui a lista de jogadores de quando o jogador digita "/jogando".
-    if line.contains("[CHAT] Jogadores") && !app_mutex.lock().await.state.loading {
+    else if line.contains("[CHAT] Jogadores") && !app_mutex.lock().await.state.loading {
         println!("Jogador digitou /jogando");
         let split = line.split("):").map(|x| x.to_string());
         let split_vector: Vec<String> = split.clone().collect();

--- a/src/MainView.vue
+++ b/src/MainView.vue
@@ -15,7 +15,7 @@ let loading = toRef(store, 'loading');
 
 let settings = toRef(store, 'settings');
 
-let text = ref("Olá! Entre no ip 127.0.0.1:25567 e digite /ver no chat ou use o atalho shift+alt+e para usar o KC Overlay.")
+let text = ref("Entre no ip 127.0.0.1:25567 e digite /ver no chat ou use o atalho shift+alt+e para usar o KC Overlay.")
 let copyFeedback = ref(false);
 
 const copyToClipboard = async () => {
@@ -40,6 +40,14 @@ listen("not_logged", () => {
     <TitleBar :update_url="update_url"></TitleBar>
     <PlayerTable v-if="players.length > 0" :party_players="party_players" :players="players" :settings="settings" :loading="loading"></PlayerTable>
     <div v-else class="info-container">
+
+        <p>Utilize o comando <span style="color:#3eedad">/block + tab</span> </p>
+        <p>no servidor para abrir a overlay dentro do jogo.</p>
+
+        <div class="separator">
+            <span>ou</span>
+        </div>
+
         <p class="info-text">{{ text }}</p>
         <div class="ip-section">
             <span class="ip-label">IP do Servidor:</span>
@@ -50,6 +58,7 @@ listen("not_logged", () => {
                 </button>
             </div>
         </div>
+
     </div>
 </template>
 
@@ -62,7 +71,26 @@ listen("not_logged", () => {
 .info-text {
     margin-bottom: 20px;
     font-size: 1rem;
-    color: #ccc;
+}
+
+.separator {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin: 20px 0;
+}
+
+.separator span {
+    padding: 0 15px;
+    position: relative;
+}
+
+.separator::before,
+.separator::after {
+    content: '';
+    flex: 1;
+    height: 1px;
+    background-color: #45475a;
 }
 
 .ip-section {


### PR DESCRIPTION
Adicionando a utilização de /block + tab para listagem de jogadores.
Isso remove parcialmente a necessidade de usar um passthrough para utilizar o /ver. Tornando menos complexo para o usuário pois não tem necessidade direta de efetuar login com a Microsoft e usar o proxy.